### PR TITLE
Fix and Update _config.yml to point to license instead of 404

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ menu:
 # Add links to the footer.
 legal:
   - title:             LICENSE
-    external_url:      https://github.com/hpc-social.github.io/blob/main/LICENSE
+    external_url:      https://github.com/hpc-social/hpc-social.github.io/blob/main/LICENSE
   - title:             CHANGELOG
     url:               /CHANGELOG/
 


### PR DESCRIPTION
Was previously pointing to https://github.com/hpc-social.github.io/blob/main/LICENSE, which 404's. I assume this was due to the repo previously not being part of an org? 

Regardless, this should have it now point to the correct place in the repos license from within the org. 

Alternative is to point to an embedded GPLv3 license page within the site (already have one here: https://hpc-social.github.io/LICENSE)