### PR TITLE
Fix link to community map

### DIFF
--- a/_projects/map.md
+++ b/_projects/map.md
@@ -11,7 +11,7 @@ links:
 caption: Starting a map of community members
 description: >
   Where is the HPC social and friends community located? Add yourself anonymously to our
-  <a class="link" href="https://github.com/hpc-social/map" target="_blank">community map</a>! 
+  <a class="link" href="https://hpc.social/map" target="_blank">community map</a>! 
   <br>
 accent_color: '#4fb1ba'
 ---


### PR DESCRIPTION
Link to community. map should go there instead of to the GitHub page for the project. Fixed.