### PR TITLE
add contact links and disable drawer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -320,7 +320,6 @@ social:
     - https://github.com/<hpc-social>
 
 
-
 # Plugin Configs
 # ---------------------------------------------------------------------------------------
 optional_front_matter:

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 url:                   https://hpc-social.github.io
 lang:                  en
 title:                 HPC.social
+baseurl:               ""
 
 description:           >
  A community of high performance computing practitioners and friends.

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,8 @@ menu:
     url:               /projects/
   - title:             News
     url:               /news/
+  - title:             Discussion
+    external_url:      https://github.com/hpc-social/hpc-social.github.io/discussions
 
 # Add links to the footer.
 legal:
@@ -149,7 +151,7 @@ hydejack:
   no_push_state:       false
 
   # Set to `true` if you want to disable the drawer
-  no_drawer:           false
+  no_drawer:           true
 
   # Set to `true` if you don't to use the auto-hiding (JavaScript based) navbar.
   # Note that this will not hide the navbar completely, only replace it with a static one.

--- a/_includes/body/nav.html
+++ b/_includes/body/nav.html
@@ -2,12 +2,12 @@
 <ul>
   {% if site.menu %}
     {% for node in site.menu %}
-      {% assign url = node.url | default: node.href %}
+      {% if node.external_url %}{% assign url = node.external_url | default: node.href %}{% else %}{% assign url = node.url | default: node.href %}{% endif %}
       <li>
         <a
           {% if forloop.first %}id="_drawer--opened"{% endif %}
           href="{% include_cached smart-url url=url %}"
-          class="sidebar-nav-item {% if node.external  %}external{% endif %}"
+          class="sidebar-nav-item {% if node.external  %}external{% endif %}" {% if node.external_url %}target="_blank"{% endif %}
           {% if node.rel %}rel="{{ node.rel }}"{% endif %}
         >
           {{ node.name | default:node.title }}

--- a/_projects/mastodon.md
+++ b/_projects/mastodon.md
@@ -26,6 +26,8 @@ accent_image:
 
 We are proud to provide the HPC community with a Mastodon instance at
 <a class="link" href="https://mast.hpc.social" target="_blank">mast.hpc.social</a>! 
+You can check out <a href="https://mast.hpc.social/directory" target="_blank">community profiles here</a>,
+and find important contacts, policy, and <a href="https://mast.hpc.social/about" target="_blank">details here</a>
 
 The policy documents linked here are served from <a href="https://github.com/hpc-social/mastodon-policies" target="_blank">hpc-social/mastodon-policies</a> on GitHub. You can ask questions, or make contributions or suggestions for changes there.
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -12,7 +12,9 @@ We will be updating this site in the coming months - stay tuned!
 ## Community
 
 * [Projects]{:.heading.flip-title} --- Maintained by the community.
+* [Discussions]{:.heading.flip-title} --- Community Discussion
 * [News]{:.heading.flip-title} --- Latest news and announcements.
+
 {:.related-posts.faded}
 
 ## Resources
@@ -21,3 +23,4 @@ We will be updating this site in the coming months - stay tuned!
 
 [projects]: projects/
 [news]: news/
+[discussions]: https://github.com/hpc-social/hpc-social.github.io/discussions


### PR DESCRIPTION
@alansill I think I'd like your feedback on these changes before merging! Specifically:

- I added the discussions link front and center (the main pages) and the Mastodon links (profile and about) on the Mastodon project page - I think that's where people will want to find them or go looking for them, and we can think about some more general "contact" page later.
- I find the drawer kind of distracting? I think the user should come to the site and make a choice to click on something. And then it should not be possible to erroneously go back (this was a bug detected by @alecbcs) so I've disabled the drawer for now.
- I'm fairly picky about external links opening to blank, so I've fixed this at least for our opening page. External links on the rest of the site either need to be explicitly defined, or some other tweak I haven't found yet.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>