### PR TITLE
Add "Join Us On Mastodon" link to menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,8 @@ menu:
     url:               /news/
   - title:             Discussion
     external_url:      https://github.com/hpc-social/hpc-social.github.io/discussions
+  - title:             Join Us On Mastodon
+    external_url:      https://mast.hpc-social.github.io/about
 
 # Add links to the footer.
 legal:


### PR DESCRIPTION
Apparently people just want a direct link to find out how to sign up for mast.hpc.social so add a link to this in the menu.