### PR TITLE
Revert "Add "Join Us On Mastodon" link to menu"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,6 @@ menu:
     url:               /news/
   - title:             Discussion
     external_url:      https://github.com/hpc-social/hpc-social.github.io/discussions
-  - title:             Join Us On Mastodon
-    external_url:      https://mast.hpc-social.github.io/about
 
 # Add links to the footer.
 legal:


### PR DESCRIPTION
Reverts hpc-social/hpc-social.github.io#35

The link is showing up as mast.hpc-social.github.io which is incorrect.