### PR TITLE
Add link to chat projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,8 @@ menu:
     external_url:      https://github.com/hpc-social/hpc-social.github.io/discussions
   - title:             Mastodon
     url:               /projects/mastodon/
+  - title:             Chat
+    url:               /projects/chat/
 
 # Add links to the footer.
 legal:


### PR DESCRIPTION
Add link to Project page for Slack and Discord - note join and sign in links are on that page