### PR TITLE
Add Sponsor link to main menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,8 @@ menu:
     url:               /projects/chat/
   - title:             Jobs
     url:               /projects/jobs/
+  - title:             Sponsor
+    url:               /sponsors/
 
 # Add links to the footer.
 legal:


### PR DESCRIPTION
Add link to Sponsors page, which with the most recent proposed change, will have a sponsor button at the top of the page.

We can change that to a direct link to the GitHub sponsors page later if that seems better.